### PR TITLE
v5.0.2 Global stats fix

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "com.heyzeusv.solitaire"
         minSdk = 24
         targetSdk = 34
-        versionCode = 24
-        versionName = "5.0.1"
+        versionCode = 25
+        versionName = "5.0.2"
 
         testInstrumentationRunner = "com.heyzeusv.solitaire.util.CustomTestRunner"
         vectorDrawables {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,16 +82,16 @@ android {
 }
 
 dependencies {
-    val compose = "2024.02.02"
+    val compose = "2024.05.00"
     val hiltVersion = "2.50"
     val lifecycleVersion = "2.7.0"
     val firebase = "33.0.0"
 
     implementation("org.jetbrains.kotlin:kotlin-reflect:1.9.20")
 
-    implementation("androidx.core:core-ktx:1.12.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
-    implementation("androidx.activity:activity-compose:1.8.2")
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion")
+    implementation("androidx.activity:activity-compose:1.9.0")
     implementation(platform("androidx.compose:compose-bom:$compose"))
     implementation("androidx.lifecycle:lifecycle-runtime-compose:$lifecycleVersion")
     implementation("com.google.android.play:integrity:1.3.0")
@@ -120,7 +120,7 @@ dependencies {
     implementation("androidx.compose.material3:material3")
 
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.1")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
     testImplementation("io.kotest:kotest-runner-junit5:5.8.1")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/assets/Changelog.txt
+++ b/app/src/main/assets/Changelog.txt
@@ -1,3 +1,6 @@
+v5.0.2
+-Fixed: Global stats are now correctly shown on sync.
+
 v5.0.1
 -Fixed: Message for account status.
 

--- a/app/src/main/java/com/heyzeusv/solitaire/MainActivity.kt
+++ b/app/src/main/java/com/heyzeusv/solitaire/MainActivity.kt
@@ -106,6 +106,9 @@ fun SolitaireApp(
     LaunchedEffect(key1 = settings.selectedGame) {
         gameVM.updateSelectedGame(Games.getGameClass(settings.selectedGame))
     }
+    LaunchedEffect(key1 = isConnected) {
+        menuVM.isConnected = isConnected
+    }
     LifecycleResumeEffect {
         if (gameVM.sbLogic.moves.value != 0) gameVM.sbLogic.startTimer()
         onPauseOrDispose { gameVM.sbLogic.pauseTimer() }

--- a/app/src/main/java/com/heyzeusv/solitaire/MainActivity.kt
+++ b/app/src/main/java/com/heyzeusv/solitaire/MainActivity.kt
@@ -138,7 +138,6 @@ fun SolitaireApp(
         ) {
             composable(route = NavScreens.Splash.route) {
                 SplashScreen(
-                    isConnected = isConnected,
                     navController = appState.navController,
                     menuVM = menuVM
                 )

--- a/app/src/main/java/com/heyzeusv/solitaire/menu/MenuViewModel.kt
+++ b/app/src/main/java/com/heyzeusv/solitaire/menu/MenuViewModel.kt
@@ -19,6 +19,7 @@ import com.heyzeusv.solitaire.util.MenuState
 import com.heyzeusv.solitaire.menu.settings.SettingsManager
 import com.heyzeusv.solitaire.menu.stats.getStatsDefaultInstance
 import com.heyzeusv.solitaire.service.StorageService
+import com.heyzeusv.solitaire.service.toFsGameStats
 import com.heyzeusv.solitaire.service.toGameStatsList
 import com.heyzeusv.solitaire.service.toFsGameStatsList
 import com.heyzeusv.solitaire.util.SnackbarManager
@@ -126,6 +127,9 @@ class MenuViewModel @Inject constructor(
         viewModelScope.launch {
             statManager.updateStats(selectedGS, selectedUploadGS)
             statManager.updateStats(allGS, allUploadGS)
+            if (accountService.hasUser) {
+                storageService.uploadStatsAfterGame(selectedGS.toFsGameStats(), allGS.toFsGameStats())
+            }
         }
     }
 

--- a/app/src/main/java/com/heyzeusv/solitaire/menu/MenuViewModel.kt
+++ b/app/src/main/java/com/heyzeusv/solitaire/menu/MenuViewModel.kt
@@ -2,7 +2,6 @@ package com.heyzeusv.solitaire.menu
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.auth.FirebaseAuthException
 import com.heyzeusv.solitaire.Game
 import com.heyzeusv.solitaire.GameStats
 import com.heyzeusv.solitaire.R
@@ -185,16 +184,6 @@ class MenuViewModel @Inject constructor(
                     statManager.updateUID(accountService.currentUserId)
                     statManager.clearGameStatsToUpload()
                 }
-            }
-        }
-    }
-
-    fun createAnonymousAccount() {
-        launchCatching {
-            try {
-                accountService.createAnonymousAccount()
-            } catch (ex: FirebaseAuthException) {
-                SnackbarManager.showMessage(ex.toSnackbarMessage())
             }
         }
     }

--- a/app/src/main/java/com/heyzeusv/solitaire/menu/MenuViewModel.kt
+++ b/app/src/main/java/com/heyzeusv/solitaire/menu/MenuViewModel.kt
@@ -182,8 +182,7 @@ class MenuViewModel @Inject constructor(
                     if (statsFlow.value.uid != "") {
                         statManager.deleteAllPersonalStats()
                     } else {
-                        storageService.uploadPersonalStats(stats.statsList.toFsGameStatsList())
-                        storageService.uploadGlobalStats(stats.statsList.toFsGameStatsList())
+                        storageService.uploadStatsOnSignUp(stats.statsList.toFsGameStatsList())
                     }
                     statManager.updateUID(accountService.currentUserId)
                     statManager.clearGameStatsToUpload()
@@ -267,15 +266,6 @@ class MenuViewModel @Inject constructor(
         launchCatching {
             _accountStatus.value = UploadPersonalStats()
             statManager.updateGameStatsUploadTimes()
-            val gamesToUpload = stats.gameStatsToUploadList.map { it.game }
-            val gsToUpload = stats.statsList.filter { gs -> gamesToUpload.contains(gs.game) }
-                .toFsGameStatsList()
-            storageService.uploadPersonalStats(gsToUpload)
-            _accountStatus.value = UploadGlobalStats()
-            storageService.uploadGlobalStats(stats.gameStatsToUploadList.toFsGameStatsList())
-            _accountStatus.value = DownloadGlobalStats()
-            val globalStats = storageService.downloadGlobalStats()
-            statManager.addAllGlobalStats(globalStats.toGameStatsList())
             statManager.clearGameStatsToUpload()
         }
     }

--- a/app/src/main/java/com/heyzeusv/solitaire/service/AccountService.kt
+++ b/app/src/main/java/com/heyzeusv/solitaire/service/AccountService.kt
@@ -38,10 +38,6 @@ class AccountService @Inject constructor(private val auth: FirebaseAuth) {
 
     }
 
-    suspend fun createAnonymousAccount() {
-        auth.signInAnonymously().await()
-    }
-
     fun signOut() {
         auth.signOut()
         _userAccount.value = null

--- a/app/src/main/java/com/heyzeusv/solitaire/service/FsGameStats.kt
+++ b/app/src/main/java/com/heyzeusv/solitaire/service/FsGameStats.kt
@@ -1,13 +1,12 @@
 package com.heyzeusv.solitaire.service
 
 import androidx.annotation.Keep
-import com.google.firebase.firestore.DocumentId
 import com.heyzeusv.solitaire.GameStats
 import com.heyzeusv.solitaire.games.Games
 
 @Keep
 data class FsGameStats(
-    @DocumentId val game: String = "",
+    val game: String = "",
     val gamesPlayed: Int = 0,
     val gamesWon: Int = 0,
     val lowestMoves: Int = 9999,
@@ -17,7 +16,7 @@ data class FsGameStats(
     val totalScore: Int = 0,
     val bestCombinedScore: Long = 99999L
 ) {
-    fun combineFsGameStats(gs: FsGameStats): FsGameStats {
+    infix fun combineWith(gs: FsGameStats): FsGameStats {
         return FsGameStats(
             game = game,
             gamesPlayed = gamesPlayed.plus(gs.gamesPlayed),
@@ -30,6 +29,7 @@ data class FsGameStats(
             bestCombinedScore = bestCombinedScore.coerceAtMost(gs.bestCombinedScore)
         )
     }
+
     fun toGameStats(): GameStats = GameStats.newBuilder().also { gs ->
         gs.game = Games.getDataStoreEnum(game)
         gs.gamesPlayed = gamesPlayed

--- a/app/src/main/java/com/heyzeusv/solitaire/splash/SplashScreen.kt
+++ b/app/src/main/java/com/heyzeusv/solitaire/splash/SplashScreen.kt
@@ -29,14 +29,10 @@ import kotlinx.coroutines.delay
  */
 @Composable
 fun SplashScreen(
-    isConnected: Boolean,
     navController: NavHostController,
     menuVM: MenuViewModel
 ) {
-    SplashScreen(
-        onStartUp = { if (isConnected) menuVM.createAnonymousAccount() },
-        createAllStats = menuVM::createAllStats
-    ) {
+    SplashScreen(createAllStats = menuVM::createAllStats) {
         navController.navigate(NavScreens.Game.route)
     }
 }
@@ -47,13 +43,11 @@ fun SplashScreen(
  */
 @Composable
 fun SplashScreen(
-    onStartUp: () -> Unit = { },
     createAllStats: () -> Unit = { },
     navigate: () -> Unit = { }
 ) {
     LaunchedEffect(key1 = Unit) {
         delay((2500L..3500L).random())
-        onStartUp()
         createAllStats()
         navigate()
     }

--- a/app/src/main/java/com/heyzeusv/solitaire/util/ExtensionFunctions.kt
+++ b/app/src/main/java/com/heyzeusv/solitaire/util/ExtensionFunctions.kt
@@ -247,22 +247,15 @@ fun String.isValidPassword(): Boolean {
     return this.isNotBlank() && Pattern.compile(PASS_PATTERN).matcher(this).matches()
 }
 
-private const val UTC_MINUS7 = 25200
-private const val DAY_IN_SECONDS = 86400
-
 /**
- *  Returns [Long] from this [Date] that represents the end of day today using UTC-7 as timezone.
+ *  Returns [Long] from this [Date] that is 5 minutes ahead.
  */
-fun Date.endOfDay(): Long {
+fun Date.inFiveMinutes(): Long {
     val dateNowSeconds = this.time / 1000
-    val timeIntoDay = (dateNowSeconds - UTC_MINUS7) % DAY_IN_SECONDS
-    return (dateNowSeconds - timeIntoDay + DAY_IN_SECONDS) * 1000
+    val fiveMinutes = 5 * 60
+    return (dateNowSeconds + fiveMinutes) * 1000
 }
 
 fun StatPreferences.retrieveLocalStatsFor(game: Game): GameStats {
     return statsList.find { it.game == game } ?: getStatsDefaultInstance(game)
-}
-
-fun StatPreferences.retrieveStatsToUploadFor(game: Game): GameStats {
-    return globalStatsList.find { it.game == game } ?: getStatsDefaultInstance(game)
 }

--- a/app/src/main/proto/stat_prefs.proto
+++ b/app/src/main/proto/stat_prefs.proto
@@ -4,12 +4,12 @@ option java_package = "com.heyzeusv.solitaire";
 option java_multiple_files = true;
 
 message StatPreferences {
-  reserved 2;
+  reserved 2, 4;
   repeated GameStats stats = 1;
   int64 next_game_stats_sync = 3;
-  repeated GameStats game_stats_to_upload = 4;
   string uid = 5;
   repeated GameStats global_stats = 6;
+  bool stats_to_upload = 7;
 }
 
 message GameStats {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,7 +150,7 @@
     <string name="account_status_download_personal_stats">Downloading personal stats…</string>
     <string name="account_status_download_global_stats">Downloading global stats…</string>
     <string name="sync_ad_title">Upload personal stats and download global stats?</string>
-    <string name="sync_ad_message">You can only sync stats once a day.</string>
+    <string name="sync_ad_message">You can only sync stats once every 5 minutes.</string>
     <string name="sync_ad_confirm">Yes</string>
     <string name="sync_ad_dismiss">No</string>
     <string name="sync_error_time">You can sync in %1$s.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,7 +103,7 @@
     <string name="about_license">License</string>
     <string name="about_special_thanks">Special thanks to family, friends, and pets for all their support!</string>
     <string name="about_translation_warning">Google Translate was used for localization. Please let me know of any mistakes, thank you!</string>
-    <string name="about_version">v5.0.1</string>
+    <string name="about_version">v5.0.2</string>
     <string name="about_privacy_policy">Privacy Policy</string>
     <string name="about_privacy_policy_link">https://doc-hosting.flycricket.io/klondike-solitaire/b4a088cc-badf-42f7-b9eb-e196ca220b1b/privacy</string>
     <string name="about_icon_credit">Card Suits by Amethyst Studio (CC BY 3.0)</string>


### PR DESCRIPTION
Global stats are no longer being kept track of in a separate collection on Firestore. Instead, they are calculated by combining all gameStats collection documents of the same name from all users. Users can now sync once every five minutes. Game stats are now uploaded after every game if signed in and connected to internet.